### PR TITLE
Fix typo

### DIFF
--- a/youearnedit/.ruby-gemset
+++ b/youearnedit/.ruby-gemset
@@ -1,1 +1,1 @@
-yoouearnedit
+youearnedit


### PR DESCRIPTION
Typo in gemset name, not super important...but why not?

Also, sup?